### PR TITLE
Switch to using constructor parameters for source information

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ kapt {
 * The generated intermediate builder has `internal` visibility for its constructor and `build()` 
 methods, which can be considered a bit of a leaky API. If you use this, it's recommended to put 
 your models in a separate module to avoid leaking this.
-* Properties must be `internal` or `public` visibility. The generated builder properties will match 
-their corresponding class properties.
+* Properties must be `internal` or `public` visibility.
 
 Download
 --------

--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ kapt {
 }
 ```
 
-**Caveats**: The generated intermediate builder has `internal` visibility for its constructor and `build()` 
+**Caveats**
+* The generated intermediate builder has `internal` visibility for its constructor and `build()` 
 methods, which can be considered a bit of a leaky API. If you use this, it's recommended to put 
 your models in a separate module to avoid leaking this.
+* Properties must be `internal` or `public` visibility. The generated builder properties will match 
+their corresponding class properties.
 
 Download
 --------

--- a/copydynamic/src/main/kotlin/io/sweers/copydynamic/CopyDynamicProcessor.kt
+++ b/copydynamic/src/main/kotlin/io/sweers/copydynamic/CopyDynamicProcessor.kt
@@ -204,12 +204,6 @@ class CopyDynamicProcessor : AbstractProcessor() {
           parametersByName.forEach { (name, parameter) ->
             addProperty(PropertySpec.varBuilder(name,
                 parameter.type.asTypeName(nameResolver, classData::getTypeParameter, true))
-                .apply {
-                  // Match the visibility of the corresponding property
-                  propertiesByName[name]?.visibility?.asKModifier()?.let {
-                    addModifiers(it)
-                  }
-                }
                 .initializer("%N.%L", sourceParam, name)
                 .build()
                 .also { properties.add(name to it) }

--- a/sample/src/test/kotlin/io/sweers/copydynamic/sample/test/CopyDynamicTest.kt
+++ b/sample/src/test/kotlin/io/sweers/copydynamic/sample/test/CopyDynamicTest.kt
@@ -53,8 +53,34 @@ class CopyDynamicTest {
   @CopyDynamic
   data class FooGeneric<T>(val bar: String = "bar", val baz: String = "baz", val fizz: T)
 
+  /**
+   * An internal class. This should compile fine because the visibility should match
+   */
   @CopyDynamic
   internal data class InternalFoo(val bar: String = "bar")
+
+  /**
+   * Properties not in the constructor
+   */
+  @Test
+  fun fooWithInternalProperties() {
+    val foo = FooWithInternalProps(bar = "fizz")
+    val someCondition = true
+    val newFoo = foo.copyDynamic {
+      bar = "newBar"
+      if (someCondition) internalBar = "newInternalBar"
+    }
+
+    assertThat(newFoo.bar).isEqualTo("newBar")
+    assertThat(newFoo.internalBar).isEqualTo("newInternalBar")
+    assertThat(newFoo.baz).isEqualTo("newBar")
+  }
+
+  @CopyDynamic
+  internal data class FooWithInternalProps(val bar: String = "bar",
+      internal val internalBar: String = "internalBar") {
+    val baz: String = bar
+  }
 }
 
 

--- a/sample/src/test/kotlin/io/sweers/copydynamic/sample/test/CopyDynamicTest.kt
+++ b/sample/src/test/kotlin/io/sweers/copydynamic/sample/test/CopyDynamicTest.kt
@@ -65,20 +65,16 @@ class CopyDynamicTest {
   @Test
   fun fooWithInternalProperties() {
     val foo = FooWithInternalProps(bar = "fizz")
-    val someCondition = true
     val newFoo = foo.copyDynamic {
       bar = "newBar"
-      if (someCondition) internalBar = "newInternalBar"
     }
 
     assertThat(newFoo.bar).isEqualTo("newBar")
-    assertThat(newFoo.internalBar).isEqualTo("newInternalBar")
     assertThat(newFoo.baz).isEqualTo("newBar")
   }
 
   @CopyDynamic
-  internal data class FooWithInternalProps(val bar: String = "bar",
-      internal val internalBar: String = "internalBar") {
+  internal data class FooWithInternalProps(val bar: String = "bar") {
     val baz: String = bar
   }
 }


### PR DESCRIPTION
We were mistakenly using the property list directly before, which we shouldn't do.

This also adds a few more important checks around minimum visibility of the parameters (`internal` or `private`)