### PR TITLE
Use NameAllocator to avoid parameter name collisions

### DIFF
--- a/copydynamic/src/main/kotlin/io/sweers/copydynamic/CopyDynamicProcessor.kt
+++ b/copydynamic/src/main/kotlin/io/sweers/copydynamic/CopyDynamicProcessor.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.NameAllocator
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
@@ -170,6 +171,11 @@ class CopyDynamicProcessor : AbstractProcessor() {
       return
     }
 
+    // Create a NameAllocator and fill its cache with existing parameter names so we don't collide
+    // with our own parameter name
+    val nameAllocator = NameAllocator()
+    parametersByName.keys.forEach { nameAllocator.newName(it) }
+
     val packageName = MoreElements.getPackage(element).toString()
     val builderName = "${element.simpleName}DynamicBuilder"
     val typeParams = classData.typeParameterList
@@ -182,7 +188,7 @@ class CopyDynamicProcessor : AbstractProcessor() {
       }
     }
     val visibility = classData.visibility?.asKModifier()
-    val sourceParam = ParameterSpec.builder("source", sourceType).build()
+    val sourceParam = ParameterSpec.builder(nameAllocator.newName("source"), sourceType).build()
     val properties = mutableListOf<Pair<String, PropertySpec>>()
     val builderSpec = TypeSpec.classBuilder(builderName)
         .apply {

--- a/sample/src/test/kotlin/io/sweers/copydynamic/sample/test/CopyDynamicTest.kt
+++ b/sample/src/test/kotlin/io/sweers/copydynamic/sample/test/CopyDynamicTest.kt
@@ -77,6 +77,14 @@ class CopyDynamicTest {
   internal data class FooWithInternalProps(val bar: String = "bar") {
     val baz: String = bar
   }
+
+  /**
+   * This should compile even though it has a `source` property, which we use for the internal name
+   * of the source item. Extra `source_` for extra stress testing.
+   */
+  @CopyDynamic
+  internal data class FooWithSourceVal(val source: String,
+      val source_: String)
 }
 
 


### PR DESCRIPTION
There was a bug before that if you had a parameter called `source`, it collided with our own parameter name in the builder and fail to compile