### PR TITLE
Shade autocommon and kotlinpoet

### DIFF
--- a/copydynamic/build.gradle
+++ b/copydynamic/build.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.zip.ZipException
+
 plugins {
   id 'com.github.johnrengelman.shadow' version '2.0.4'
   id 'org.jetbrains.kotlin.jvm'
@@ -37,7 +41,7 @@ shadowJar {
   relocate 'com.google', 'copydynamic.shaded.com.google'
   relocate 'afu', 'copydynamic.shaded.afu'
   relocate 'org', 'copydynamic.shaded.org'
-  exclude 'javax.*'
+  exclude 'javax/**'
 }
 
 artifacts {
@@ -66,5 +70,38 @@ compileKotlin {
     freeCompilerArgs = ['-Xjsr305=strict', '-Xprogressive']
   }
 }
+
+class VerifyShadowTask extends DefaultTask {
+
+  private static final Set<String> ALLOWED_JAR_ENTRIES = new LinkedHashSet<>(Arrays.asList("io/", "copydynamic/", "META-INF/"))
+
+  @TaskAction
+  void check() {
+    getLogger().debug("Verifying shadowJar contents")
+    File jar = project.file("${project.buildDir}/libs")
+        .listFiles()
+        .find { File file ->
+          file.name.endsWith(".jar") && !file.name.contains("-javadoc") && !file.name.contains("-sources")
+        }
+
+    if (jar == null) {
+      throw new RuntimeException("Jar not found!")
+    }
+
+    try {
+      JarFile jarFile = new JarFile(jar)
+      jarFile.entries().each { JarEntry entry ->
+        if (!ALLOWED_JAR_ENTRIES.any { entry.getName().startsWith(it) }) {
+          throw new RuntimeException("Jar contains unexpected entry: \"${entry.getName()}\"")
+        }
+      }
+    } catch (ZipException e) {
+      throw new RuntimeException("Couldn't open ${jar.name}", e)
+    }
+  }
+}
+
+task verifyShadow(type: VerifyShadowTask, dependsOn: shadowJar)
+tasks.check.dependsOn(verifyShadow)
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/copydynamic/build.gradle
+++ b/copydynamic/build.gradle
@@ -15,9 +15,34 @@
  */
 
 plugins {
+  id 'com.github.johnrengelman.shadow' version '2.0.4'
   id 'org.jetbrains.kotlin.jvm'
   id 'org.jetbrains.kotlin.kapt'
   id 'org.jetbrains.dokka'
+}
+
+// disable default jar tasks
+configurations.runtime.artifacts.removeAll { it.archiveTask.is jar }
+tasks.getByName('jar').enabled = false
+
+// create extra configuration for shaded dependencies, so they're not included in the pom
+def shadedConfig = configurations.create('compileShaded')
+configurations.compileOnly.extendsFrom(shadedConfig)
+
+shadowJar {
+  classifier = ''
+  configurations = [shadedConfig]
+
+  relocate 'com.squareup.kotlinpoet', 'copydynamic.shaded.com.squareup.kotlinpoet'
+  relocate 'com.google', 'copydynamic.shaded.com.google'
+  relocate 'afu', 'copydynamic.shaded.afu'
+  relocate 'org', 'copydynamic.shaded.org'
+  exclude 'javax.*'
+}
+
+artifacts {
+  runtime shadowJar
+  archives shadowJar
 }
 
 dependencies {
@@ -26,10 +51,13 @@ dependencies {
 
   compile project(':copydynamic-annotations')
 
-  compile deps.apt.autoCommon
+  compileShaded deps.apt.autoCommon
+  compileShaded(deps.misc.kotlinpoet) {
+    transitive = false
+  }
   compile deps.misc.kotlinMetadata
+  compile deps.kotlin.reflect
   compile deps.kotlin.stdlibjdk8
-  compile deps.misc.kotlinpoet
 }
 
 compileKotlin {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,6 +34,7 @@ def build = [
 ]
 
 def kotlin = [
+    reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}",
     stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
     stdlibjdk7: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
     stdlibjdk8: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"


### PR DESCRIPTION
Autocommon because it's fairly standard to shade google core library dependencies (it also isn't a stable API and pulls in a ton of transitives), kotlinpoet because it's not a stable API yet.

This was finicky to get working, but feeling confident about catching new changes with the verify task added