### PR TITLE
Remove build function and use inline run + copy instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ kapt {
 ```
 
 **Caveats**
-* The generated intermediate builder has `internal` visibility for its constructor and `build()` 
-methods, which can be considered a bit of a leaky API. If you use this, it's recommended to put 
+* The generated intermediate builder has `internal` visibility for its constructor, which can be considered a bit of a leaky API. If you use this, it's recommended to put 
 your models in a separate module to avoid leaking this.
 * Properties must be `internal` or `public` visibility.
 


### PR DESCRIPTION
Avoids a leaky build API that isn't necessary

Now it looks like this

```kotlin
class TacoDynamicBuilder internal constructor(private val source: Taco) {
  var seasoning: Set<String> = source.seasoning
  var isBreakfast: Boolean = source.isBreakfast
}

fun Taco.copyDynamic(copyBlock: TacoDynamicBuilder.() -> Unit): Taco {
  return TacoDynamicBuilder(this)
      .also { copyBlock(it) }
      .run {
        copy(
            seasoning = seasoning,
            isBreakfast = isBreakfast
        )
      }
}
```