### PR TITLE
Shade kotlinx-metadata

### DIFF
--- a/copydynamic/build.gradle
+++ b/copydynamic/build.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id 'com.github.johnrengelman.shadow' version '4.0.1'
+  id 'com.github.johnrengelman.shadow' version '5.0.0'
   id 'org.jetbrains.kotlin.jvm'
   id 'org.jetbrains.kotlin.kapt'
   id 'org.jetbrains.dokka'

--- a/copydynamic/build.gradle
+++ b/copydynamic/build.gradle
@@ -53,7 +53,6 @@ dependencies {
   implementation project(':copydynamic-annotations')
   implementation project(':metric')
   implementation deps.misc.kotlinpoet
-  implementation deps.misc.kotlinxMetdata
   implementation deps.kotlin.reflect
   implementation deps.kotlin.stdlibjdk8
 }

--- a/metric/build.gradle
+++ b/metric/build.gradle
@@ -33,14 +33,13 @@ shadowJar {
   relocate 'com.google', 'metric.shaded.com.google'
   relocate 'afu', 'metric.shaded.afu'
   relocate 'org', 'metric.shaded.org'
+  relocate 'kotlinx.metadata', 'metric.shaded.kotlinx.metadata'
   exclude 'javax/**'
 
   // Service files are not included by default.
   mergeServiceFiles {
     include 'META-INF/services/*'
   }
-
-  relocate 'kotlinx.metadata', 'metric.shaded.kotlinx.metadata'
 }
 artifacts {
   runtime shadowJar

--- a/metric/build.gradle
+++ b/metric/build.gradle
@@ -34,6 +34,13 @@ shadowJar {
   relocate 'afu', 'metric.shaded.afu'
   relocate 'org', 'metric.shaded.org'
   exclude 'javax/**'
+
+  // Service files are not included by default.
+  mergeServiceFiles {
+    include 'META-INF/services/*'
+  }
+
+  relocate 'kotlinx.metadata', 'metric.shaded.kotlinx.metadata'
 }
 artifacts {
   runtime shadowJar
@@ -48,6 +55,9 @@ dependencies {
   implementation deps.kotlin.stdlibjdk8
   implementationShaded deps.apt.autoCommon
 
+  implementationShaded deps.misc.kotlinxMetdata
+
+  testImplementation deps.misc.kotlinxMetdata
   testImplementation deps.test.junit
   testImplementation deps.test.truth
 }

--- a/metric/build.gradle
+++ b/metric/build.gradle
@@ -50,7 +50,6 @@ artifacts {
 
 dependencies {
   implementation deps.misc.kotlinpoet
-  implementation deps.misc.kotlinxMetdata
   implementation deps.kotlin.reflect
   implementation deps.kotlin.stdlibjdk8
   implementationShaded deps.apt.autoCommon

--- a/metric/build.gradle
+++ b/metric/build.gradle
@@ -51,8 +51,8 @@ dependencies {
   implementation deps.misc.kotlinpoet
   implementation deps.kotlin.reflect
   implementation deps.kotlin.stdlibjdk8
-  implementationShaded deps.apt.autoCommon
 
+  implementationShaded deps.apt.autoCommon
   implementationShaded deps.misc.kotlinxMetdata
 
   testImplementation deps.misc.kotlinxMetdata

--- a/metric/build.gradle
+++ b/metric/build.gradle
@@ -38,7 +38,7 @@ shadowJar {
 
   // Service files are not included by default.
   mergeServiceFiles {
-    include 'META-INF/services/*'
+    include 'META-INF/services/kotlinx.metadata.*'
   }
 }
 artifacts {
@@ -53,7 +53,9 @@ dependencies {
   implementation deps.kotlin.stdlibjdk8
 
   implementationShaded deps.apt.autoCommon
-  implementationShaded deps.misc.kotlinxMetdata
+  implementationShaded(deps.misc.kotlinxMetdata) {
+    transitive = false
+  }
 
   testImplementation deps.misc.kotlinxMetdata
   testImplementation deps.test.junit

--- a/metric/build.gradle
+++ b/metric/build.gradle
@@ -27,7 +27,10 @@ tasks.getByName('jar').enabled = false
 def shadedConfig = configurations.create('implementationShaded')
 configurations.compileOnly.extendsFrom(shadedConfig)
 shadowJar {
-  minimize()
+  minimize {
+    // Otherwise it strips the JvmMetadataExtensions impl that's loaded via ServiceLoader
+    exclude(dependency(deps.misc.kotlinxMetdata)) 
+  }
   archiveClassifier.set('')
   configurations = [shadedConfig]
   relocate 'com.google', 'metric.shaded.com.google'

--- a/metric/build.gradle
+++ b/metric/build.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id 'com.github.johnrengelman.shadow' version '4.0.1'
+  id 'com.github.johnrengelman.shadow' version '5.0.0'
   id 'org.jetbrains.kotlin.jvm'
   id 'org.jetbrains.dokka'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,6 +19,10 @@ plugins {
   id 'org.jetbrains.kotlin.kapt'
 }
 
+repositories {
+  mavenLocal()
+}
+
 dependencies {
   kapt project(':copydynamic')
   compile project(':copydynamic-annotations')


### PR DESCRIPTION
Need to get services shading to work properly. _Almost_ works, but weirdly the `JvmMetadataExtensions` is the one class that's not getting relocated and weirdly missing from the entire result, and that's the one referenced by the service file

```
An exception occurred: java.util.ServiceConfigurationError: copydynamic.shaded.kotlinx.metadata.impl.extensions.MetadataExtensions: Provider copydynamic.shaded.kotlinx.metadata.jvm.impl.JvmMetadataExtensions not found
```