### PR TITLE
Immutable metric implementations

### DIFF
--- a/metric/src/main/kotlin/io/sweers/metric/Flags.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/Flags.kt
@@ -50,6 +50,17 @@ internal val KmClass.isPrivate_to_this: Boolean get() = flags.isPrivate_to_this
 internal val KmClass.isProtected: Boolean get() = flags.isProtected
 internal val KmClass.isPublic: Boolean get() = flags.isPublic
 internal val KmClass.isSealed: Boolean get() = flags.isSealed
+internal val ImmutableKmClass.hasAnnotations: Boolean get() = flags.hasAnnotations
+internal val ImmutableKmClass.isAbstract: Boolean get() = flags.isAbstract
+internal val ImmutableKmClass.isFinal: Boolean get() = flags.isFinal
+internal val ImmutableKmClass.isInternal: Boolean get() = flags.isInternal
+internal val ImmutableKmClass.isLocal: Boolean get() = flags.isLocal
+internal val ImmutableKmClass.isOpen: Boolean get() = flags.isOpen
+internal val ImmutableKmClass.isPrivate: Boolean get() = flags.isPrivate
+internal val ImmutableKmClass.isPrivate_to_this: Boolean get() = flags.isPrivate_to_this
+internal val ImmutableKmClass.isProtected: Boolean get() = flags.isProtected
+internal val ImmutableKmClass.isPublic: Boolean get() = flags.isPublic
+internal val ImmutableKmClass.isSealed: Boolean get() = flags.isSealed
 
 // Type flags.
 internal val Flags.isNullableType: Boolean get() = Flag.Type.IS_NULLABLE(this)
@@ -82,11 +93,27 @@ internal val KmClass.isObject: Boolean get() = flags.isObjectClass
 internal val KmClass.isInterface: Boolean get() = flags.isInterface
 internal val KmType.isSuspend: Boolean get() = flags.isSuspendType
 internal val KmType.isNullable: Boolean get() = flags.isNullableType
+internal val ImmutableKmClass.isAnnotation: Boolean get() = flags.isAnnotationClass
+internal val ImmutableKmClass.isClass: Boolean get() = flags.isClass
+internal val ImmutableKmClass.isCompanionObject: Boolean get() = flags.isCompanionObjectClass
+internal val ImmutableKmClass.isData: Boolean get() = flags.isDataClass
+internal val ImmutableKmClass.isEnum: Boolean get() = flags.isEnumClass
+internal val ImmutableKmClass.isEnumEntry: Boolean get() = flags.isEnumEntryClass
+internal val ImmutableKmClass.isExpect: Boolean get() = flags.isExpectClass
+internal val ImmutableKmClass.isExternal: Boolean get() = flags.isExternalClass
+internal val ImmutableKmClass.isInline: Boolean get() = flags.isInlineClass
+internal val ImmutableKmClass.isInner: Boolean get() = flags.isInnerClass
+internal val ImmutableKmClass.isObject: Boolean get() = flags.isObjectClass
+internal val ImmutableKmClass.isInterface: Boolean get() = flags.isInterface
+internal val ImmutableKmType.isSuspend: Boolean get() = flags.isSuspendType
+internal val ImmutableKmType.isNullable: Boolean get() = flags.isNullableType
 
 // Constructor flags.
 internal val Flags.isPrimaryConstructor: Boolean get() = Flag.Constructor.IS_PRIMARY(this)
 internal val KmConstructor.isPrimary: Boolean get() = flags.isPrimaryConstructor
 internal val KmConstructor.isSecondary: Boolean get() = !isPrimary
+internal val ImmutableKmConstructor.isPrimary: Boolean get() = flags.isPrimaryConstructor
+internal val ImmutableKmConstructor.isSecondary: Boolean get() = !isPrimary
 
 // Function flags.
 internal val Flags.isDeclarationFunction: Boolean get() = Flag.Function.IS_DECLARATION(this)
@@ -111,15 +138,28 @@ internal val KmFunction.isTailRec: Boolean get() = flags.isTailRecFunction
 internal val KmFunction.isExternal: Boolean get() = flags.isExternalFunction
 internal val KmFunction.isSuspend: Boolean get() = flags.isSuspendFunction
 internal val KmFunction.isExpect: Boolean get() = flags.isExpectFunction
+internal val ImmutableKmFunction.isDeclaration: Boolean get() = flags.isDeclarationFunction
+internal val ImmutableKmFunction.isFakeOverride: Boolean get() = flags.isFakeOverrideFunction
+internal val ImmutableKmFunction.isDelegation: Boolean get() = flags.isDelegationFunction
+internal val ImmutableKmFunction.isSynthesized: Boolean get() = flags.isSynthesizedFunction
+internal val ImmutableKmFunction.isOperator: Boolean get() = flags.isOperatorFunction
+internal val ImmutableKmFunction.isInfix: Boolean get() = flags.isInfixFunction
+internal val ImmutableKmFunction.isInline: Boolean get() = flags.isInlineFunction
+internal val ImmutableKmFunction.isTailRec: Boolean get() = flags.isTailRecFunction
+internal val ImmutableKmFunction.isExternal: Boolean get() = flags.isExternalFunction
+internal val ImmutableKmFunction.isSuspend: Boolean get() = flags.isSuspendFunction
+internal val ImmutableKmFunction.isExpect: Boolean get() = flags.isExpectFunction
 
 // Parameter flags.
-internal val KmValueParameter.declaresDefaultValue: Boolean
-  get() = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(flags)
-internal val KmValueParameter.isCrossInline: Boolean
-  get() = Flag.ValueParameter.IS_CROSSINLINE(flags)
+internal val KmValueParameter.declaresDefaultValue: Boolean get() = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(flags)
+internal val KmValueParameter.isCrossInline: Boolean get() = Flag.ValueParameter.IS_CROSSINLINE(flags)
 internal val KmValueParameter.isNoInline: Boolean get() = Flag.ValueParameter.IS_NOINLINE(flags)
+internal val ImmutableKmValueParameter.declaresDefaultValue: Boolean get() = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(flags)
+internal val ImmutableKmValueParameter.isCrossInline: Boolean get() = Flag.ValueParameter.IS_CROSSINLINE(flags)
+internal val ImmutableKmValueParameter.isNoInline: Boolean get() = Flag.ValueParameter.IS_NOINLINE(flags)
 
 // Property flags.
+internal val Flags.isOverrideProperty: Boolean get() = Flag.Property.IS_FAKE_OVERRIDE(this)
 internal val KmProperty.hasConstant: Boolean get() = Flag.Property.HAS_CONSTANT(flags)
 internal val KmProperty.hasGetter: Boolean get() = Flag.Property.HAS_GETTER(flags)
 internal val KmProperty.hasSetter: Boolean get() = Flag.Property.HAS_SETTER(flags)
@@ -129,12 +169,25 @@ internal val KmProperty.isDelegated: Boolean get() = Flag.Property.IS_DELEGATED(
 internal val KmProperty.isDelegation: Boolean get() = Flag.Property.IS_DELEGATION(flags)
 internal val KmProperty.isExpect: Boolean get() = Flag.Property.IS_EXPECT(flags)
 internal val KmProperty.isExternal: Boolean get() = Flag.Property.IS_EXTERNAL(flags)
-internal val Flags.isOverrideProperty: Boolean get() = Flag.Property.IS_FAKE_OVERRIDE(this)
 internal val KmProperty.isOverride: Boolean get() = flags.isOverrideProperty
 internal val KmProperty.isLateinit: Boolean get() = Flag.Property.IS_LATEINIT(flags)
 internal val KmProperty.isSynthesized: Boolean get() = Flag.Property.IS_SYNTHESIZED(flags)
 internal val KmProperty.isVar: Boolean get() = Flag.Property.IS_VAR(flags)
 internal val KmProperty.isVal: Boolean get() = !isVar
+internal val ImmutableKmProperty.hasConstant: Boolean get() = Flag.Property.HAS_CONSTANT(flags)
+internal val ImmutableKmProperty.hasGetter: Boolean get() = Flag.Property.HAS_GETTER(flags)
+internal val ImmutableKmProperty.hasSetter: Boolean get() = Flag.Property.HAS_SETTER(flags)
+internal val ImmutableKmProperty.isConst: Boolean get() = Flag.Property.IS_CONST(flags)
+internal val ImmutableKmProperty.isDeclaration: Boolean get() = Flag.Property.IS_DECLARATION(flags)
+internal val ImmutableKmProperty.isDelegated: Boolean get() = Flag.Property.IS_DELEGATED(flags)
+internal val ImmutableKmProperty.isDelegation: Boolean get() = Flag.Property.IS_DELEGATION(flags)
+internal val ImmutableKmProperty.isExpect: Boolean get() = Flag.Property.IS_EXPECT(flags)
+internal val ImmutableKmProperty.isExternal: Boolean get() = Flag.Property.IS_EXTERNAL(flags)
+internal val ImmutableKmProperty.isOverride: Boolean get() = flags.isOverrideProperty
+internal val ImmutableKmProperty.isLateinit: Boolean get() = Flag.Property.IS_LATEINIT(flags)
+internal val ImmutableKmProperty.isSynthesized: Boolean get() = Flag.Property.IS_SYNTHESIZED(flags)
+internal val ImmutableKmProperty.isVar: Boolean get() = Flag.Property.IS_VAR(flags)
+internal val ImmutableKmProperty.isVal: Boolean get() = !isVar
 
 // Property Accessor Flags
 internal val Flags.isPropertyAccessorExternal: Boolean
@@ -145,6 +198,7 @@ internal val Flags.isPropertyAccessorNotDefault: Boolean
 
 // TypeParameter flags.
 internal val KmTypeParameter.isReified: Boolean get() = Flag.TypeParameter.IS_REIFIED(flags)
+internal val ImmutableKmTypeParameter.isReified: Boolean get() = Flag.TypeParameter.IS_REIFIED(flags)
 
 internal val Flags.propertyAccessorFlags: Set<KModifier>
   get() = setOf {

--- a/metric/src/main/kotlin/io/sweers/metric/Metric.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/Metric.kt
@@ -28,15 +28,9 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
-import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmClassifier.TypeAlias
 import kotlinx.metadata.KmClassifier.TypeParameter
-import kotlinx.metadata.KmConstructor
-import kotlinx.metadata.KmFlexibleTypeUpperBound
-import kotlinx.metadata.KmType
-import kotlinx.metadata.KmTypeParameter
-import kotlinx.metadata.KmTypeProjection
 import kotlinx.metadata.KmVariance
 import kotlinx.metadata.KmVariance.IN
 import kotlinx.metadata.KmVariance.INVARIANT
@@ -66,7 +60,7 @@ fun Metadata.readKmClass(): TypeSpec {
   return when (val metadata = readKotlinClassMetadata()) {
     //  return when (metadata) {
     is KotlinClassMetadata.Class -> {
-      metadata.toKmClass().asTypeSpec()
+      metadata.toImmutableKmClass().asTypeSpec()
     }
     is FileFacade -> TODO()
     is SyntheticClass -> TODO()
@@ -105,7 +99,7 @@ internal fun Metadata.asClassHeader(): KotlinClassHeader {
   )
 }
 
-val KmClass.primaryConstructor: KmConstructor?
+val ImmutableKmClass.primaryConstructor: ImmutableKmConstructor?
   get() = constructors.find { it.isPrimary }
 
 internal fun KmVariance.asKModifier(): KModifier? {
@@ -116,7 +110,7 @@ internal fun KmVariance.asKModifier(): KModifier? {
   }
 }
 
-internal fun KmTypeProjection.asTypeName(
+internal fun ImmutableKmTypeProjection.asTypeName(
     typeParamResolver: ((index: Int) -> TypeName)
 ): TypeName {
   val typename = type?.asTypeName(typeParamResolver) ?: STAR
@@ -136,7 +130,7 @@ internal fun KmTypeProjection.asTypeName(
   }
 }
 
-internal fun KmType.asTypeName(
+internal fun ImmutableKmType.asTypeName(
     typeParamResolver: ((index: Int) -> TypeName),
     useTypeAlias: Boolean = false
 ): TypeName {
@@ -191,7 +185,7 @@ internal fun KmType.asTypeName(
   return type.copy(nullable = isNullable)
 }
 
-internal fun KmTypeParameter.asTypeVariableName(
+internal fun ImmutableKmTypeParameter.asTypeVariableName(
     typeParamResolver: ((index: Int) -> TypeName)
 ): TypeVariableName {
   val finalVariance = variance.asKModifier().let {
@@ -217,7 +211,7 @@ internal fun KmTypeParameter.asTypeVariableName(
   return typeVariableName.copy(reified = isReified)
 }
 
-private fun KmFlexibleTypeUpperBound.asTypeName(
+private fun ImmutableKmFlexibleTypeUpperBound.asTypeName(
     typeParamResolver: ((index: Int) -> TypeName)
 ): TypeName {
   // TODO tag typeFlexibilityId somehow?

--- a/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
@@ -224,7 +224,7 @@ fun KmFunction.immutable(): ImmutableKmFunction {
       flags,
       name,
       typeParameters.map { it.immutable() },
-      receiverParameterType,
+      receiverParameterType?.immutable(),
       valueParameters.map { it.immutable() },
       returnType.immutable(),
       versionRequirements.map { it.immutable() },
@@ -250,7 +250,7 @@ data class ImmutableKmFunction internal constructor(
     val flags: Flags,
     val name: String,
     val typeParameters: List<ImmutableKmTypeParameter>,
-    val receiverParameterType: KmType?,
+    val receiverParameterType: ImmutableKmType?,
     val valueParameters: List<ImmutableKmValueParameter>,
     val returnType: ImmutableKmType,
     val versionRequirements: List<ImmutableKmVersionRequirement>,
@@ -259,7 +259,7 @@ data class ImmutableKmFunction internal constructor(
   fun mutable(): KmFunction {
     return KmFunction(flags, name).apply {
       typeParameters += this@ImmutableKmFunction.typeParameters.map { it.mutable() }
-      receiverParameterType = this@ImmutableKmFunction.receiverParameterType
+      receiverParameterType = this@ImmutableKmFunction.receiverParameterType?.mutable()
       valueParameters += this@ImmutableKmFunction.valueParameters.map { it.mutable() }
       returnType = this@ImmutableKmFunction.returnType.mutable()
       versionRequirements += this@ImmutableKmFunction.versionRequirements.map { it.mutable() }
@@ -455,7 +455,7 @@ fun KmType.immutable(): ImmutableKmType {
       arguments.map { it.immutable() },
       abbreviatedType?.immutable(),
       outerType?.immutable(),
-      flexibleTypeUpperBound
+      flexibleTypeUpperBound?.immutable()
   )
 }
 
@@ -498,7 +498,7 @@ data class ImmutableKmType internal constructor(
      *
      * Flexible types in Kotlin include platform types in Kotlin/JVM and `dynamic` type in Kotlin/JS.
      */
-    val flexibleTypeUpperBound: KmFlexibleTypeUpperBound?
+    val flexibleTypeUpperBound: ImmutableKmFlexibleTypeUpperBound?
 ) {
   fun mutable(): KmType {
     return KmType(flags).apply {
@@ -506,7 +506,7 @@ data class ImmutableKmType internal constructor(
       arguments += this@ImmutableKmType.arguments.map { it.mutable() }
       abbreviatedType = this@ImmutableKmType.abbreviatedType?.mutable()
       outerType = this@ImmutableKmType.outerType?.mutable()
-      flexibleTypeUpperBound = this@ImmutableKmType.flexibleTypeUpperBound
+      flexibleTypeUpperBound = this@ImmutableKmType.flexibleTypeUpperBound?.mutable()
     }
   }
 }

--- a/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
@@ -56,17 +56,17 @@ fun KmClass.immutable(): ImmutableKmClass {
   return ImmutableKmClass(
       flags,
       name,
-      typeParameters.unmodifiable(),
-      supertypes.unmodifiable(),
-      functions.unmodifiable(),
-      properties.unmodifiable(),
-      typeAliases.unmodifiable(),
-      constructors.unmodifiable(),
+      typeParameters.map { it.immutable() },
+      supertypes.map { it.immutable() },
+      functions.map { it.immutable() },
+      properties.map { it.immutable() },
+      typeAliases.map { it.immutable() },
+      constructors.map { it.immutable() },
       companionObject,
       nestedClasses.unmodifiable(),
       enumEntries.unmodifiable(),
       sealedSubclasses.unmodifiable(),
-      versionRequirements
+      versionRequirements.map { it.immutable() }
   )
 }
 
@@ -92,33 +92,33 @@ fun KmClass.immutable(): ImmutableKmClass {
 data class ImmutableKmClass internal constructor(
     val flags: Flags,
     val name: ClassName,
-    val typeParameters: List<KmTypeParameter>,
-    val supertypes: List<KmType>,
-    val functions: List<KmFunction>,
-    val properties: List<KmProperty>,
-    val typeAliases: List<KmTypeAlias>,
-    val constructors: List<KmConstructor>,
+    val typeParameters: List<ImmutableKmTypeParameter>,
+    val supertypes: List<ImmutableKmType>,
+    val functions: List<ImmutableKmFunction>,
+    val properties: List<ImmutableKmProperty>,
+    val typeAliases: List<ImmutableKmTypeAlias>,
+    val constructors: List<ImmutableKmConstructor>,
     val companionObject: String?,
     val nestedClasses: List<String>,
     val enumEntries: List<String>,
     val sealedSubclasses: List<ClassName>,
-    val versionRequirements: List<KmVersionRequirement>
+    val versionRequirements: List<ImmutableKmVersionRequirement>
 ) {
   fun mutable(): KmClass {
     return KmClass().apply {
       flags = this@ImmutableKmClass.flags
       name = this@ImmutableKmClass.name
-      typeParameters += this@ImmutableKmClass.typeParameters
-      supertypes += this@ImmutableKmClass.supertypes
-      functions += this@ImmutableKmClass.functions
-      properties += this@ImmutableKmClass.properties
-      typeAliases += this@ImmutableKmClass.typeAliases
-      constructors += this@ImmutableKmClass.constructors
+      typeParameters += this@ImmutableKmClass.typeParameters.map { it.mutable() }
+      supertypes += this@ImmutableKmClass.supertypes.map { it.mutable() }
+      functions += this@ImmutableKmClass.functions.map { it.mutable() }
+      properties += this@ImmutableKmClass.properties.map { it.mutable() }
+      typeAliases += this@ImmutableKmClass.typeAliases.map { it.mutable() }
+      constructors += this@ImmutableKmClass.constructors.map { it.mutable() }
       companionObject = this@ImmutableKmClass.companionObject
       nestedClasses += this@ImmutableKmClass.nestedClasses
       enumEntries += this@ImmutableKmClass.enumEntries
       sealedSubclasses += this@ImmutableKmClass.sealedSubclasses
-      versionRequirements += this@ImmutableKmClass.versionRequirements
+      versionRequirements += this@ImmutableKmClass.versionRequirements.map { it.mutable() }
     }
   }
 }
@@ -127,9 +127,9 @@ data class ImmutableKmClass internal constructor(
 @JvmName("immutableOf")
 fun KmPackage.immutable(): ImmutableKmPackage {
   return ImmutableKmPackage(
-      functions.unmodifiable(),
-      properties.unmodifiable(),
-      typeAliases.unmodifiable()
+      functions.map { it.immutable() },
+      properties.map { it.immutable() },
+      typeAliases.map { it.immutable() }
   )
 }
 
@@ -143,15 +143,15 @@ fun KmPackage.immutable(): ImmutableKmPackage {
  * @property typeAliases typeAliases in the package fragment.
  */
 data class ImmutableKmPackage internal constructor(
-    val functions: List<KmFunction>,
-    val properties: List<KmProperty>,
-    val typeAliases: List<KmTypeAlias>
+    val functions: List<ImmutableKmFunction>,
+    val properties: List<ImmutableKmProperty>,
+    val typeAliases: List<ImmutableKmTypeAlias>
 ) {
   fun mutable(): KmPackage {
     return KmPackage().apply {
-      functions += this@ImmutableKmPackage.functions
-      properties += this@ImmutableKmPackage.properties
-      typeAliases += this@ImmutableKmPackage.typeAliases
+      functions += this@ImmutableKmPackage.functions.map { it.mutable() }
+      properties += this@ImmutableKmPackage.properties.map { it.mutable() }
+      typeAliases += this@ImmutableKmPackage.typeAliases.map { it.mutable() }
     }
   }
 }
@@ -182,8 +182,8 @@ data class ImmutableKmLambda internal constructor(val function: KmFunction) {
 fun KmConstructor.immutable(): ImmutableKmConstructor {
   return ImmutableKmConstructor(
       flags = flags,
-      valueParameters = valueParameters.unmodifiable(),
-      versionRequirements = versionRequirements.unmodifiable()
+      valueParameters = valueParameters.map { it.immutable() },
+      versionRequirements = versionRequirements.map { it.immutable() }
   )
 }
 
@@ -198,13 +198,13 @@ fun KmConstructor.immutable(): ImmutableKmConstructor {
  */
 data class ImmutableKmConstructor internal constructor(
     val flags: Flags,
-    val valueParameters: List<KmValueParameter>,
-    val versionRequirements: List<KmVersionRequirement>
+    val valueParameters: List<ImmutableKmValueParameter>,
+    val versionRequirements: List<ImmutableKmVersionRequirement>
 ) {
   fun mutable(): KmConstructor {
     return KmConstructor(flags).apply {
-      valueParameters += this@ImmutableKmConstructor.valueParameters
-      versionRequirements += this@ImmutableKmConstructor.versionRequirements
+      valueParameters += this@ImmutableKmConstructor.valueParameters.map { it.mutable() }
+      versionRequirements += this@ImmutableKmConstructor.versionRequirements.map { it.mutable() }
     }
   }
 }
@@ -215,11 +215,11 @@ fun KmFunction.immutable(): ImmutableKmFunction {
   return ImmutableKmFunction(
       flags,
       name,
-      typeParameters.unmodifiable(),
+      typeParameters.map { it.immutable() },
       receiverParameterType,
-      valueParameters.unmodifiable(),
+      valueParameters.map { it.immutable() },
       returnType,
-      versionRequirements.unmodifiable(),
+      versionRequirements.map { it.immutable() },
       contract
   )
 }
@@ -241,20 +241,20 @@ fun KmFunction.immutable(): ImmutableKmFunction {
 data class ImmutableKmFunction internal constructor(
     val flags: Flags,
     val name: String,
-    val typeParameters: List<KmTypeParameter>,
+    val typeParameters: List<ImmutableKmTypeParameter>,
     val receiverParameterType: KmType?,
-    val valueParameters: List<KmValueParameter>,
+    val valueParameters: List<ImmutableKmValueParameter>,
     val returnType: KmType,
-    val versionRequirements: List<KmVersionRequirement>,
+    val versionRequirements: List<ImmutableKmVersionRequirement>,
     val contract: KmContract?
 ) {
   fun mutable(): KmFunction {
     return KmFunction(flags, name).apply {
-      typeParameters += this@ImmutableKmFunction.typeParameters
+      typeParameters += this@ImmutableKmFunction.typeParameters.map { it.mutable() }
       receiverParameterType = this@ImmutableKmFunction.receiverParameterType
-      valueParameters += this@ImmutableKmFunction.valueParameters
+      valueParameters += this@ImmutableKmFunction.valueParameters.map { it.mutable() }
       returnType = this@ImmutableKmFunction.returnType
-      versionRequirements += this@ImmutableKmFunction.versionRequirements
+      versionRequirements += this@ImmutableKmFunction.versionRequirements.map { it.mutable() }
       contract = this@ImmutableKmFunction.contract
     }
   }
@@ -268,11 +268,11 @@ fun KmProperty.immutable(): ImmutableKmProperty {
       name,
       getterFlags,
       setterFlags,
-      typeParameters.unmodifiable(),
+      typeParameters.map { it.immutable() },
       receiverParameterType,
       setterParameter,
       returnType,
-      versionRequirements.unmodifiable()
+      versionRequirements.map { it.immutable() }
   )
 }
 
@@ -298,19 +298,19 @@ data class ImmutableKmProperty internal constructor(
     val name: String,
     val getterFlags: Flags,
     val setterFlags: Flags,
-    val typeParameters: List<KmTypeParameter>,
+    val typeParameters: List<ImmutableKmTypeParameter>,
     val receiverParameterType: KmType?,
     val setterParameter: KmValueParameter?,
     val returnType: KmType,
-    val versionRequirements: List<KmVersionRequirement>
+    val versionRequirements: List<ImmutableKmVersionRequirement>
 ) {
   fun mutable(): KmProperty {
     return KmProperty(flags, name, getterFlags, setterFlags).apply {
-      typeParameters += this@ImmutableKmProperty.typeParameters
+      typeParameters += this@ImmutableKmProperty.typeParameters.map { it.mutable() }
       receiverParameterType = this@ImmutableKmProperty.receiverParameterType
       setterParameter = this@ImmutableKmProperty.setterParameter
       returnType = this@ImmutableKmProperty.returnType
-      versionRequirements += this@ImmutableKmProperty.versionRequirements
+      versionRequirements += this@ImmutableKmProperty.versionRequirements.map { it.mutable() }
     }
   }
 }
@@ -321,11 +321,11 @@ fun KmTypeAlias.immutable(): ImmutableKmTypeAlias {
   return ImmutableKmTypeAlias(
       flags,
       name,
-      typeParameters.unmodifiable(),
+      typeParameters.map { it.immutable() },
       underlyingType,
       expandedType,
       annotations.unmodifiable(),
-      versionRequirements.unmodifiable()
+      versionRequirements.map { it.immutable() }
   )
 }
 
@@ -348,19 +348,19 @@ fun KmTypeAlias.immutable(): ImmutableKmTypeAlias {
 data class ImmutableKmTypeAlias internal constructor(
     val flags: Flags,
     val name: String,
-    val typeParameters: List<KmTypeParameter>,
+    val typeParameters: List<ImmutableKmTypeParameter>,
     val underlyingType: KmType,
     val expandedType: KmType,
     val annotations: List<KmAnnotation>,
-    val versionRequirements: List<KmVersionRequirement>
+    val versionRequirements: List<ImmutableKmVersionRequirement>
 ) {
   fun mutable(): KmTypeAlias {
     return KmTypeAlias(flags, name).apply {
-      typeParameters += this@ImmutableKmTypeAlias.typeParameters
+      typeParameters += this@ImmutableKmTypeAlias.typeParameters.map { it.mutable() }
       underlyingType = this@ImmutableKmTypeAlias.underlyingType
       expandedType = this@ImmutableKmTypeAlias.expandedType
       annotations += this@ImmutableKmTypeAlias.annotations
-      versionRequirements += this@ImmutableKmTypeAlias.versionRequirements
+      versionRequirements += this@ImmutableKmTypeAlias.versionRequirements.map { it.mutable() }
     }
   }
 }
@@ -408,7 +408,7 @@ fun KmTypeParameter.immutable(): ImmutableKmTypeParameter {
       name,
       id,
       variance,
-      upperBounds.unmodifiable()
+      upperBounds.map { it.immutable() }
   )
 }
 
@@ -429,11 +429,11 @@ data class ImmutableKmTypeParameter internal constructor(
     val name: String,
     val id: Int,
     val variance: KmVariance,
-    val upperBounds: List<KmType>
+    val upperBounds: List<ImmutableKmType>
 ) {
   fun mutable(): KmTypeParameter {
     return KmTypeParameter(flags, name, id, variance).apply {
-      upperBounds += this@ImmutableKmTypeParameter.upperBounds
+      upperBounds += this@ImmutableKmTypeParameter.upperBounds.map { it.mutable() }
     }
   }
 }
@@ -444,7 +444,7 @@ fun KmType.immutable(): ImmutableKmType {
   return ImmutableKmType(
       flags,
       classifier,
-      arguments.unmodifiable(),
+      arguments.map { it.immutable() },
       abbreviatedType,
       outerType,
       flexibleTypeUpperBound
@@ -463,7 +463,7 @@ fun KmType.immutable(): ImmutableKmType {
 data class ImmutableKmType internal constructor(
     val flags: Flags,
     val classifier: KmClassifier,
-    val arguments: List<KmTypeProjection>,
+    val arguments: List<ImmutableKmTypeProjection>,
     /**
      * Abbreviation of this type. Note that all types are expanded for metadata produced by the Kotlin compiler. For example:
      *
@@ -495,7 +495,7 @@ data class ImmutableKmType internal constructor(
   fun mutable(): KmType {
     return KmType(flags).apply {
       classifier = this@ImmutableKmType.classifier
-      arguments += this@ImmutableKmType.arguments
+      arguments += this@ImmutableKmType.arguments.map { it.mutable() }
       abbreviatedType = this@ImmutableKmType.abbreviatedType
       outerType = this@ImmutableKmType.outerType
       flexibleTypeUpperBound = this@ImmutableKmType.flexibleTypeUpperBound
@@ -550,7 +550,7 @@ data class ImmutableKmVersionRequirement internal constructor(
 /** @return an immutable instance of this [KmContract]. */
 @JvmName("immutableOf")
 fun KmContract.immutable(): ImmutableKmContract {
-  return ImmutableKmContract(effects.unmodifiable())
+  return ImmutableKmContract(effects.map { it.immutable() })
 }
 
 /**
@@ -563,10 +563,10 @@ fun KmContract.immutable(): ImmutableKmContract {
  *
  * @property effects Effects of this contract.
  */
-data class ImmutableKmContract internal constructor(val effects: List<KmEffect>) {
+data class ImmutableKmContract internal constructor(val effects: List<ImmutableKmEffect>) {
   fun mutable(): KmContract {
     return KmContract().apply {
-      effects += this@ImmutableKmContract.effects
+      effects += this@ImmutableKmContract.effects.map { it.mutable() }
     }
   }
 }
@@ -577,7 +577,7 @@ fun KmEffect.immutable(): ImmutableKmEffect {
   return ImmutableKmEffect(
       type,
       invocationKind,
-      constructorArguments.unmodifiable(),
+      constructorArguments.map { it.immutable() },
       conclusion
   )
 }
@@ -601,12 +601,12 @@ fun KmEffect.immutable(): ImmutableKmEffect {
 data class ImmutableKmEffect internal constructor(
     val type: KmEffectType,
     val invocationKind: KmEffectInvocationKind?,
-    val constructorArguments: List<KmEffectExpression>,
+    val constructorArguments: List<ImmutableKmEffectExpression>,
     val conclusion: KmEffectExpression?
 ) {
   fun mutable(): KmEffect {
     return KmEffect(type, invocationKind).apply {
-      constructorArguments += this@ImmutableKmEffect.constructorArguments
+      constructorArguments += this@ImmutableKmEffect.constructorArguments.map { it.mutable() }
       conclusion = this@ImmutableKmEffect.conclusion
     }
   }
@@ -620,8 +620,8 @@ fun KmEffectExpression.immutable(): ImmutableKmEffectExpression {
       parameterIndex,
       constantValue,
       isInstanceType,
-      andArguments.unmodifiable(),
-      orArguments.unmodifiable()
+      andArguments.map { it.immutable() },
+      orArguments.map { it.immutable() }
   )
 }
 
@@ -649,8 +649,8 @@ data class ImmutableKmEffectExpression internal constructor(
     val parameterIndex: Int?,
     val constantValue: KmConstantValue?,
     val isInstanceType: KmType?,
-    val andArguments: List<KmEffectExpression>,
-    val orArguments: List<KmEffectExpression>
+    val andArguments: List<ImmutableKmEffectExpression>,
+    val orArguments: List<ImmutableKmEffectExpression>
 ) {
   fun mutable(): KmEffectExpression {
     return KmEffectExpression().apply {
@@ -658,9 +658,38 @@ data class ImmutableKmEffectExpression internal constructor(
       parameterIndex = this@ImmutableKmEffectExpression.parameterIndex
       constantValue = this@ImmutableKmEffectExpression.constantValue
       isInstanceType = this@ImmutableKmEffectExpression.isInstanceType
-      andArguments += this@ImmutableKmEffectExpression.andArguments
-      orArguments += this@ImmutableKmEffectExpression.orArguments
+      andArguments += this@ImmutableKmEffectExpression.andArguments.map { it.mutable() }
+      orArguments += this@ImmutableKmEffectExpression.orArguments.map { it.mutable() }
     }
+  }
+}
+
+fun KmTypeProjection.immutable(): ImmutableKmTypeProjection {
+  return ImmutableKmTypeProjection(variance, type)
+}
+
+/**
+ * Immutable representation of [KmTypeProjection].
+ *
+ * Represents type projection used in a type argument of the type based on a class or on a type alias.
+ * For example, in `MutableMap<in String?, *>`, `in String?` is the type projection which is the first type argument of the type.
+ *
+ * @property variance the variance of the type projection, or `null` if this is a star projection
+ * @property type the projected type, or `null` if this is a star projection
+ */
+data class ImmutableKmTypeProjection(val variance: KmVariance?, val type: KmType?) {
+
+  fun mutable(): KmTypeProjection {
+    return KmTypeProjection(variance, type)
+  }
+
+  companion object {
+    /**
+     * Star projection (`*`).
+     * For example, in `MutableMap<in String?, *>`, `*` is the star projection which is the second type argument of the type.
+     */
+    @JvmField
+    val STAR = KmTypeProjection.STAR
   }
 }
 

--- a/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
@@ -679,7 +679,7 @@ fun KmTypeProjection.immutable(): ImmutableKmTypeProjection {
  * @property variance the variance of the type projection, or `null` if this is a star projection
  * @property type the projected type, or `null` if this is a star projection
  */
-data class ImmutableKmTypeProjection(val variance: KmVariance?, val type: ImmutableKmType?) {
+data class ImmutableKmTypeProjection internal constructor(val variance: KmVariance?, val type: ImmutableKmType?) {
 
   fun mutable(): KmTypeProjection {
     return KmTypeProjection(variance, type?.mutable())
@@ -710,7 +710,7 @@ fun KmFlexibleTypeUpperBound.immutable(): ImmutableKmFlexibleTypeUpperBound {
  * @property typeFlexibilityId id of the kind of flexibility this type has. For example, "kotlin.jvm.PlatformType" for JVM platform types,
  *                          or "kotlin.DynamicType" for JS dynamic type
  */
-data class ImmutableKmFlexibleTypeUpperBound(val type: ImmutableKmType,
+data class ImmutableKmFlexibleTypeUpperBound internal constructor(val type: ImmutableKmType,
     val typeFlexibilityId: String?) {
   fun mutable(): KmFlexibleTypeUpperBound {
     return KmFlexibleTypeUpperBound(type.mutable(), typeFlexibilityId)

--- a/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
@@ -48,7 +48,15 @@ import kotlinx.metadata.KmVersionRequirement
 import kotlinx.metadata.KmVersionRequirementLevel
 import kotlinx.metadata.KmVersionRequirementVersionKind
 import kotlinx.metadata.KmVersionRequirementVisitor
+import kotlinx.metadata.jvm.KotlinClassMetadata
 import java.util.Collections
+
+/**
+ * Visits metadata of this class with a new [KmClass] instance and returns an [ImmutableKmClass]
+ * instance of its values.
+ */
+fun KotlinClassMetadata.Class.toImmutableKmClass(): ImmutableKmClass =
+    toKmClass().immutable()
 
 /** @return an immutable representation of this [KmClass]. */
 @JvmName("immutableOf")

--- a/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
@@ -1,0 +1,667 @@
+/*
+ * Copyright (c) 2019 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("MemberVisibilityCanBePrivate", "unused")
+@file:JvmName("ImmutableKmTypes")
+
+package io.sweers.metric
+
+import kotlinx.metadata.ClassName
+import kotlinx.metadata.Flag
+import kotlinx.metadata.Flags
+import kotlinx.metadata.KmAnnotation
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.KmConstantValue
+import kotlinx.metadata.KmConstructor
+import kotlinx.metadata.KmContract
+import kotlinx.metadata.KmEffect
+import kotlinx.metadata.KmEffectExpression
+import kotlinx.metadata.KmEffectInvocationKind
+import kotlinx.metadata.KmEffectType
+import kotlinx.metadata.KmFlexibleTypeUpperBound
+import kotlinx.metadata.KmFunction
+import kotlinx.metadata.KmLambda
+import kotlinx.metadata.KmPackage
+import kotlinx.metadata.KmProperty
+import kotlinx.metadata.KmType
+import kotlinx.metadata.KmTypeAlias
+import kotlinx.metadata.KmTypeParameter
+import kotlinx.metadata.KmTypeProjection
+import kotlinx.metadata.KmValueParameter
+import kotlinx.metadata.KmVariance
+import kotlinx.metadata.KmVersion
+import kotlinx.metadata.KmVersionRequirement
+import kotlinx.metadata.KmVersionRequirementLevel
+import kotlinx.metadata.KmVersionRequirementVersionKind
+import kotlinx.metadata.KmVersionRequirementVisitor
+import java.util.Collections
+
+/** @return an immutable instance of this [KmClass]. */
+@JvmName("immutableOf")
+fun KmClass.immutable(): ImmutableKmClass {
+  return ImmutableKmClass(
+      flags,
+      name,
+      typeParameters.unmodifiable(),
+      supertypes.unmodifiable(),
+      functions.unmodifiable(),
+      properties.unmodifiable(),
+      typeAliases.unmodifiable(),
+      constructors.unmodifiable(),
+      companionObject,
+      nestedClasses.unmodifiable(),
+      enumEntries.unmodifiable(),
+      sealedSubclasses.unmodifiable(),
+      versionRequirements
+  )
+}
+
+/**
+ * Immutable representation of [KmClass].
+ *
+ * Represents a Kotlin class.
+ *
+ * @property flags Class flags, consisting of [Flag.HAS_ANNOTATIONS], visibility flag, modality flag and [Flag.Class] flags.
+ * @property name Name of the class.
+ * @property typeParameters Type parameters of the class.
+ * @property supertypes Supertypes of the class. The first element is the superclass (or [Any])
+ * @property functions Functions in the class.
+ * @property properties Properties in the class.
+ * @property typeAliases Type aliases in the class.
+ * @property constructors Constructors of the class.
+ * @property companionObject Name of the companion object of this class, if it has one.
+ * @property nestedClasses Names of nested classes of this class.
+ * @property enumEntries Names of enum entries, if this class is an enum class.
+ * @property sealedSubclasses Names of direct subclasses of this class, if this class is `sealed`.
+ * @property versionRequirements Version requirements on this class.
+ */
+data class ImmutableKmClass internal constructor(
+    val flags: Flags,
+    val name: ClassName,
+    val typeParameters: List<KmTypeParameter>,
+    val supertypes: List<KmType>,
+    val functions: List<KmFunction>,
+    val properties: List<KmProperty>,
+    val typeAliases: List<KmTypeAlias>,
+    val constructors: List<KmConstructor>,
+    val companionObject: String?,
+    val nestedClasses: List<String>,
+    val enumEntries: List<String>,
+    val sealedSubclasses: List<ClassName>,
+    val versionRequirements: List<KmVersionRequirement>
+) {
+  fun mutable(): KmClass {
+    return KmClass().apply {
+      flags = this@ImmutableKmClass.flags
+      name = this@ImmutableKmClass.name
+      typeParameters += this@ImmutableKmClass.typeParameters
+      supertypes += this@ImmutableKmClass.supertypes
+      functions += this@ImmutableKmClass.functions
+      properties += this@ImmutableKmClass.properties
+      typeAliases += this@ImmutableKmClass.typeAliases
+      constructors += this@ImmutableKmClass.constructors
+      companionObject = this@ImmutableKmClass.companionObject
+      nestedClasses += this@ImmutableKmClass.nestedClasses
+      enumEntries += this@ImmutableKmClass.enumEntries
+      sealedSubclasses += this@ImmutableKmClass.sealedSubclasses
+      versionRequirements += this@ImmutableKmClass.versionRequirements
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmPackage]. */
+@JvmName("immutableOf")
+fun KmPackage.immutable(): ImmutableKmPackage {
+  return ImmutableKmPackage(
+      functions.unmodifiable(),
+      properties.unmodifiable(),
+      typeAliases.unmodifiable()
+  )
+}
+
+/**
+ * Immutable representation of [KmPackage].
+ *
+ * Represents a Kotlin package fragment, including single file facades and multi-file class parts.
+ *
+ * @property functions Functions in the package fragment.
+ * @property properties properties in the package fragment.
+ * @property typeAliases typeAliases in the package fragment.
+ */
+data class ImmutableKmPackage internal constructor(
+    val functions: List<KmFunction>,
+    val properties: List<KmProperty>,
+    val typeAliases: List<KmTypeAlias>
+) {
+  fun mutable(): KmPackage {
+    return KmPackage().apply {
+      functions += this@ImmutableKmPackage.functions
+      properties += this@ImmutableKmPackage.properties
+      typeAliases += this@ImmutableKmPackage.typeAliases
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmLambda]. */
+@JvmName("immutableOf")
+fun KmLambda.immutable(): ImmutableKmLambda {
+  return ImmutableKmLambda(function)
+}
+
+/**
+ * Immutable representation of [KmLambda].
+ *
+ * Represents a synthetic class generated for a Kotlin lambda.
+ *
+ * @property function Signature of the synthetic anonymous function, representing the lambda.
+ */
+data class ImmutableKmLambda internal constructor(val function: KmFunction) {
+  fun mutable(): KmLambda {
+    return KmLambda().apply {
+      function = this@ImmutableKmLambda.function
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmConstructor]. */
+@JvmName("immutableOf")
+fun KmConstructor.immutable(): ImmutableKmConstructor {
+  return ImmutableKmConstructor(
+      flags = flags,
+      valueParameters = valueParameters.unmodifiable(),
+      versionRequirements = versionRequirements.unmodifiable()
+  )
+}
+
+/**
+ * Immutable representation of [KmConstructor].
+ *
+ * Represents a constructor of a Kotlin class.
+ *
+ * @property flags constructor flags, consisting of [Flag.HAS_ANNOTATIONS], visibility flag and [Flag.Constructor] flags
+ * @property valueParameters Value parameters of the constructor.
+ * @property versionRequirements Version requirements on the constructor.
+ */
+data class ImmutableKmConstructor internal constructor(
+    val flags: Flags,
+    val valueParameters: List<KmValueParameter>,
+    val versionRequirements: List<KmVersionRequirement>
+) {
+  fun mutable(): KmConstructor {
+    return KmConstructor(flags).apply {
+      valueParameters += this@ImmutableKmConstructor.valueParameters
+      versionRequirements += this@ImmutableKmConstructor.versionRequirements
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmFunction]. */
+@JvmName("immutableOf")
+fun KmFunction.immutable(): ImmutableKmFunction {
+  return ImmutableKmFunction(
+      flags,
+      name,
+      typeParameters.unmodifiable(),
+      receiverParameterType,
+      valueParameters.unmodifiable(),
+      returnType,
+      versionRequirements.unmodifiable(),
+      contract
+  )
+}
+
+/**
+ * Immutable representation of [KmFunction].
+ *
+ * Represents a Kotlin function declaration.
+ *
+ * @property flags function flags, consisting of [Flag.HAS_ANNOTATIONS], visibility flag, modality flag and [Flag.Function] flags
+ * @property name the name of the function
+ * @property typeParameters Type parameters of the function.
+ * @property receiverParameterType Type of the receiver of the function, if this is an extension function.
+ * @property valueParameters Value parameters of the function.
+ * @property returnType Return type of the function.
+ * @property versionRequirements Version requirements on the function.
+ * @property contract Contract of the function.
+ */
+data class ImmutableKmFunction internal constructor(
+    val flags: Flags,
+    val name: String,
+    val typeParameters: List<KmTypeParameter>,
+    val receiverParameterType: KmType?,
+    val valueParameters: List<KmValueParameter>,
+    val returnType: KmType,
+    val versionRequirements: List<KmVersionRequirement>,
+    val contract: KmContract?
+) {
+  fun mutable(): KmFunction {
+    return KmFunction(flags, name).apply {
+      typeParameters += this@ImmutableKmFunction.typeParameters
+      receiverParameterType = this@ImmutableKmFunction.receiverParameterType
+      valueParameters += this@ImmutableKmFunction.valueParameters
+      returnType = this@ImmutableKmFunction.returnType
+      versionRequirements += this@ImmutableKmFunction.versionRequirements
+      contract = this@ImmutableKmFunction.contract
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmProperty]. */
+@JvmName("immutableOf")
+fun KmProperty.immutable(): ImmutableKmProperty {
+  return ImmutableKmProperty(
+      flags,
+      name,
+      getterFlags,
+      setterFlags,
+      typeParameters.unmodifiable(),
+      receiverParameterType,
+      setterParameter,
+      returnType,
+      versionRequirements.unmodifiable()
+  )
+}
+
+/**
+ * Immutable representation of [KmProperty].
+ *
+ * Represents a Kotlin property declaration.
+ *
+ * @property flags property flags, consisting of [Flag.HAS_ANNOTATIONS], visibility flag, modality flag and [Flag.Property] flags
+ * @property name the name of the property
+ * @property getterFlags property accessor flags, consisting of [Flag.HAS_ANNOTATIONS], visibility flag, modality flag
+ *   and [Flag.PropertyAccessor] flags
+ * @property setterFlags property accessor flags, consisting of [Flag.HAS_ANNOTATIONS], visibility flag, modality flag
+ *   and [Flag.PropertyAccessor] flags
+ * @property typeParameters Type parameters of the property.
+ * @property receiverParameterType Type of the receiver of the property, if this is an extension property.
+ * @property setterParameter Value parameter of the setter of this property, if this is a `var` property.
+ * @property returnType Type of the property.
+ * @property versionRequirements Version requirements on the property.
+ */
+data class ImmutableKmProperty internal constructor(
+    val flags: Flags,
+    val name: String,
+    val getterFlags: Flags,
+    val setterFlags: Flags,
+    val typeParameters: List<KmTypeParameter>,
+    val receiverParameterType: KmType?,
+    val setterParameter: KmValueParameter?,
+    val returnType: KmType,
+    val versionRequirements: List<KmVersionRequirement>
+) {
+  fun mutable(): KmProperty {
+    return KmProperty(flags, name, getterFlags, setterFlags).apply {
+      typeParameters += this@ImmutableKmProperty.typeParameters
+      receiverParameterType = this@ImmutableKmProperty.receiverParameterType
+      setterParameter = this@ImmutableKmProperty.setterParameter
+      returnType = this@ImmutableKmProperty.returnType
+      versionRequirements += this@ImmutableKmProperty.versionRequirements
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmTypeAlias]. */
+@JvmName("immutableOf")
+fun KmTypeAlias.immutable(): ImmutableKmTypeAlias {
+  return ImmutableKmTypeAlias(
+      flags,
+      name,
+      typeParameters.unmodifiable(),
+      underlyingType,
+      expandedType,
+      annotations.unmodifiable(),
+      versionRequirements.unmodifiable()
+  )
+}
+
+/**
+ * Immutable representation of [KmTypeAlias].
+ *
+ * Represents a Kotlin type alias declaration.
+ *
+ * @property flags type alias flags, consisting of [Flag.HAS_ANNOTATIONS] and visibility flag
+ * @property name the name of the type alias
+ * @property typeParameters Type parameters of the type alias.
+ * @property underlyingType Underlying type of the type alias, i.e. the type in the right-hand side of the type alias declaration.
+ * @property expandedType Expanded type of the type alias, i.e. the full expansion of the underlying
+ *                        type, where all type aliases are substituted with their expanded types. If
+ *                        no type aliases are used in the underlying type, expanded type is equal to
+ *                        the underlying type.
+ * @property annotations Annotations on the type alias.
+ * @property versionRequirements Version requirements on the type alias.
+ */
+data class ImmutableKmTypeAlias internal constructor(
+    val flags: Flags,
+    val name: String,
+    val typeParameters: List<KmTypeParameter>,
+    val underlyingType: KmType,
+    val expandedType: KmType,
+    val annotations: List<KmAnnotation>,
+    val versionRequirements: List<KmVersionRequirement>
+) {
+  fun mutable(): KmTypeAlias {
+    return KmTypeAlias(flags, name).apply {
+      typeParameters += this@ImmutableKmTypeAlias.typeParameters
+      underlyingType = this@ImmutableKmTypeAlias.underlyingType
+      expandedType = this@ImmutableKmTypeAlias.expandedType
+      annotations += this@ImmutableKmTypeAlias.annotations
+      versionRequirements += this@ImmutableKmTypeAlias.versionRequirements
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmValueParameter]. */
+@JvmName("immutableOf")
+fun KmValueParameter.immutable(): ImmutableKmValueParameter {
+  return ImmutableKmValueParameter(
+      flags,
+      name,
+      type,
+      varargElementType
+  )
+}
+
+/**
+ * Immutable representation of [KmValueParameter].
+ *
+ * Represents a value parameter of a Kotlin constructor, function or property setter.
+ *
+ * @property flags value parameter flags, consisting of [Flag.ValueParameter] flags
+ * @property name the name of the value parameter
+ * @property type Type of the value parameter, if this is **not** a `vararg` parameter.
+ * @property varargElementType Type of the value parameter, if this is a `vararg` parameter.
+ */
+data class ImmutableKmValueParameter internal constructor(
+    val flags: Flags,
+    val name: String,
+    val type: KmType?,
+    val varargElementType: KmType?
+) {
+  fun mutable(): KmValueParameter {
+    return KmValueParameter(flags, name).apply {
+      type = this@ImmutableKmValueParameter.type
+      varargElementType = this@ImmutableKmValueParameter.varargElementType
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmTypeParameter]. */
+@JvmName("immutableOf")
+fun KmTypeParameter.immutable(): ImmutableKmTypeParameter {
+  return ImmutableKmTypeParameter(
+      flags,
+      name,
+      id,
+      variance,
+      upperBounds.unmodifiable()
+  )
+}
+
+/**
+ * Immutable representation of [KmTypeParameter].
+ *
+ * Represents a type parameter of a Kotlin class, function, property or type alias.
+ *
+ * @property flags type parameter flags, consisting of [Flag.TypeParameter] flags
+ * @property name the name of the type parameter
+ * @property id the id of the type parameter, useful to be able to uniquely identify the type parameter in different contexts where
+ *           the name isn't enough (e.g. `class A<T> { fun <T> foo(t: T) }`)
+ * @property variance the declaration-site variance of the type parameter
+ * @property upperBounds Upper bounds of the type parameter.
+ */
+data class ImmutableKmTypeParameter internal constructor(
+    val flags: Flags,
+    val name: String,
+    val id: Int,
+    val variance: KmVariance,
+    val upperBounds: List<KmType>
+) {
+  fun mutable(): KmTypeParameter {
+    return KmTypeParameter(flags, name, id, variance).apply {
+      upperBounds += this@ImmutableKmTypeParameter.upperBounds
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmType]. */
+@JvmName("immutableOf")
+fun KmType.immutable(): ImmutableKmType {
+  return ImmutableKmType(
+      flags,
+      classifier,
+      arguments.unmodifiable(),
+      abbreviatedType,
+      outerType,
+      flexibleTypeUpperBound
+  )
+}
+
+/**
+ * Immutable representation of [KmType].
+ *
+ * Represents a type.
+ *
+ * @property flags type flags, consisting of [Flag.Type] flags
+ * @property classifier Classifier of the type.
+ * @property arguments Arguments of the type, if the type's classifier is a class or a type alias.
+ */
+data class ImmutableKmType internal constructor(
+    val flags: Flags,
+    val classifier: KmClassifier,
+    val arguments: List<KmTypeProjection>,
+    /**
+     * Abbreviation of this type. Note that all types are expanded for metadata produced by the Kotlin compiler. For example:
+     *
+     *     typealias A<T> = MutableList<T>
+     *
+     *     fun foo(a: A<Any>) {}
+     *
+     * The type of the `foo`'s parameter in the metadata is actually `MutableList<Any>`, and its abbreviation is `A<Any>`.
+     */
+    val abbreviatedType: KmType?,
+    /**
+     * Outer type of this type, if this type's classifier is an inner class. For example:
+     *
+     *     class A<T> { inner class B<U> }
+     *
+     *     fun foo(a: A<*>.B<Byte?>) {}
+     *
+     * The type of the `foo`'s parameter in the metadata is `B<Byte>` (a type whose classifier is class `B`, and it has one type argument,
+     * type `Byte?`), and its outer type is `A<*>` (a type whose classifier is class `A`, and it has one type argument, star projection).
+     */
+    val outerType: KmType?,
+    /**
+     * Upper bound of this type, if this type is flexible. In that case, all other data refers to the lower bound of the type.
+     *
+     * Flexible types in Kotlin include platform types in Kotlin/JVM and `dynamic` type in Kotlin/JS.
+     */
+    val flexibleTypeUpperBound: KmFlexibleTypeUpperBound?
+) {
+  fun mutable(): KmType {
+    return KmType(flags).apply {
+      classifier = this@ImmutableKmType.classifier
+      arguments += this@ImmutableKmType.arguments
+      abbreviatedType = this@ImmutableKmType.abbreviatedType
+      outerType = this@ImmutableKmType.outerType
+      flexibleTypeUpperBound = this@ImmutableKmType.flexibleTypeUpperBound
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmVersionRequirement]. */
+@JvmName("immutableOf")
+fun KmVersionRequirement.immutable(): ImmutableKmVersionRequirement {
+  return ImmutableKmVersionRequirement(
+      kind,
+      level,
+      errorCode,
+      message,
+      version
+  )
+}
+
+/**
+ * Immutable representation of [KmVersionRequirement].
+ *
+ * Represents a version requirement on a Kotlin declaration.
+ *
+ * Version requirement is an internal feature of the Kotlin compiler and the standard Kotlin library,
+ * enabled for example with the internal [kotlin.internal.RequireKotlin] annotation.
+ *
+ * @property kind Kind of the version that this declaration requires.
+ * @property level Level of the diagnostic that must be reported on the usages of the declaration in case the version requirement is not satisfied.
+ * @property errorCode Optional error code to be displayed in the diagnostic.
+ * @property message Optional message to be displayed in the diagnostic.
+ * @property version Version required by this requirement.
+ */
+data class ImmutableKmVersionRequirement internal constructor(
+    val kind: KmVersionRequirementVersionKind,
+    val level: KmVersionRequirementLevel,
+    val errorCode: Int?,
+    val message: String?,
+    val version: KmVersion
+) : KmVersionRequirementVisitor() {
+  fun mutable(): KmVersionRequirement {
+    return KmVersionRequirement().apply {
+      kind = this@ImmutableKmVersionRequirement.kind
+      level = this@ImmutableKmVersionRequirement.level
+      errorCode = this@ImmutableKmVersionRequirement.errorCode
+      message = this@ImmutableKmVersionRequirement.message
+      version = this@ImmutableKmVersionRequirement.version
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmContract]. */
+@JvmName("immutableOf")
+fun KmContract.immutable(): ImmutableKmContract {
+  return ImmutableKmContract(effects.unmodifiable())
+}
+
+/**
+ * Immutable representation of [KmContract].
+ *
+ * Represents a contract of a Kotlin function.
+ *
+ * Contracts are an internal feature of the standard Kotlin library, and their behavior and/or binary format
+ * may change in a subsequent release.
+ *
+ * @property effects Effects of this contract.
+ */
+data class ImmutableKmContract internal constructor(val effects: List<KmEffect>) {
+  fun mutable(): KmContract {
+    return KmContract().apply {
+      effects += this@ImmutableKmContract.effects
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmEffect]. */
+@JvmName("immutableOf")
+fun KmEffect.immutable(): ImmutableKmEffect {
+  return ImmutableKmEffect(
+      type,
+      invocationKind,
+      constructorArguments.unmodifiable(),
+      conclusion
+  )
+}
+
+/**
+ * Immutable representation of [KmEffect].
+ *
+ * Represents an effect (a part of the contract of a Kotlin function).
+ *
+ * Contracts are an internal feature of the standard Kotlin library, and their behavior and/or binary format
+ * may change in a subsequent release.
+ *
+ * @property type type of the effect
+ * @property invocationKind optional number of invocations of the lambda parameter of this function,
+ *   specified further in the effect expression
+ * @property constructorArguments Arguments of the effect constructor, i.e. the constant value for
+ *                                the [KmEffectType.RETURNS_CONSTANT] effect, or the parameter
+ *                                reference for the [KmEffectType.CALLS] effect.
+ * @property conclusion Conclusion of the effect. If this value is set, the effect represents an implication with this value as the right-hand side.
+ */
+data class ImmutableKmEffect internal constructor(
+    val type: KmEffectType,
+    val invocationKind: KmEffectInvocationKind?,
+    val constructorArguments: List<KmEffectExpression>,
+    val conclusion: KmEffectExpression?
+) {
+  fun mutable(): KmEffect {
+    return KmEffect(type, invocationKind).apply {
+      constructorArguments += this@ImmutableKmEffect.constructorArguments
+      conclusion = this@ImmutableKmEffect.conclusion
+    }
+  }
+}
+
+/** @return an immutable instance of this [KmEffectExpression]. */
+@JvmName("immutableOf")
+fun KmEffectExpression.immutable(): ImmutableKmEffectExpression {
+  return ImmutableKmEffectExpression(
+      flags,
+      parameterIndex,
+      constantValue,
+      isInstanceType,
+      andArguments.unmodifiable(),
+      orArguments.unmodifiable()
+  )
+}
+
+/**
+ * Immutable representation of [KmEffectExpression].
+ *
+ * Represents an effect expression, the contents of an effect (a part of the contract of a Kotlin function).
+ *
+ * Contracts are an internal feature of the standard Kotlin library, and their behavior and/or binary format
+ * may change in a subsequent release.
+ *
+ * @property flags Effect expression flags, consisting of [Flag.EffectExpression] flags.
+ * @property parameterIndex Optional 1-based index of the value parameter of the function, for
+ *                          effects which assert something about the function parameters. The index
+ *                          0 means the extension receiver parameter.
+ * @property constantValue Constant value used in the effect expression.
+ * @property isInstanceType Type used as the target of an `is`-expression in the effect expression.
+ * @property andArguments Arguments of an `&&`-expression. If this list is non-empty, the resulting
+ *                        effect expression is a conjunction of this expression and elements of the list.
+ * @property orArguments Arguments of an `||`-expression. If this list is non-empty, the resulting
+ *                       effect expression is a disjunction of this expression and elements of the list.
+ */
+data class ImmutableKmEffectExpression internal constructor(
+    val flags: Flags,
+    val parameterIndex: Int?,
+    val constantValue: KmConstantValue?,
+    val isInstanceType: KmType?,
+    val andArguments: List<KmEffectExpression>,
+    val orArguments: List<KmEffectExpression>
+) {
+  fun mutable(): KmEffectExpression {
+    return KmEffectExpression().apply {
+      flags = this@ImmutableKmEffectExpression.flags
+      parameterIndex = this@ImmutableKmEffectExpression.parameterIndex
+      constantValue = this@ImmutableKmEffectExpression.constantValue
+      isInstanceType = this@ImmutableKmEffectExpression.isInstanceType
+      andArguments += this@ImmutableKmEffectExpression.andArguments
+      orArguments += this@ImmutableKmEffectExpression.orArguments
+    }
+  }
+}
+
+private fun <E> List<E>.unmodifiable(): List<E> = Collections.unmodifiableList(this)

--- a/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
+++ b/metric/src/main/kotlin/io/sweers/metric/immutableNodes.kt
@@ -50,7 +50,7 @@ import kotlinx.metadata.KmVersionRequirementVersionKind
 import kotlinx.metadata.KmVersionRequirementVisitor
 import java.util.Collections
 
-/** @return an immutable instance of this [KmClass]. */
+/** @return an immutable representation of this [KmClass]. */
 @JvmName("immutableOf")
 fun KmClass.immutable(): ImmutableKmClass {
   return ImmutableKmClass(
@@ -123,7 +123,7 @@ data class ImmutableKmClass internal constructor(
   }
 }
 
-/** @return an immutable instance of this [KmPackage]. */
+/** @return an immutable representation of this [KmPackage]. */
 @JvmName("immutableOf")
 fun KmPackage.immutable(): ImmutableKmPackage {
   return ImmutableKmPackage(
@@ -156,10 +156,10 @@ data class ImmutableKmPackage internal constructor(
   }
 }
 
-/** @return an immutable instance of this [KmLambda]. */
+/** @return an immutable representation of this [KmLambda]. */
 @JvmName("immutableOf")
 fun KmLambda.immutable(): ImmutableKmLambda {
-  return ImmutableKmLambda(function)
+  return ImmutableKmLambda(function.immutable())
 }
 
 /**
@@ -169,15 +169,15 @@ fun KmLambda.immutable(): ImmutableKmLambda {
  *
  * @property function Signature of the synthetic anonymous function, representing the lambda.
  */
-data class ImmutableKmLambda internal constructor(val function: KmFunction) {
+data class ImmutableKmLambda internal constructor(val function: ImmutableKmFunction) {
   fun mutable(): KmLambda {
     return KmLambda().apply {
-      function = this@ImmutableKmLambda.function
+      function = this@ImmutableKmLambda.function.mutable()
     }
   }
 }
 
-/** @return an immutable instance of this [KmConstructor]. */
+/** @return an immutable representation of this [KmConstructor]. */
 @JvmName("immutableOf")
 fun KmConstructor.immutable(): ImmutableKmConstructor {
   return ImmutableKmConstructor(
@@ -209,7 +209,7 @@ data class ImmutableKmConstructor internal constructor(
   }
 }
 
-/** @return an immutable instance of this [KmFunction]. */
+/** @return an immutable representation of this [KmFunction]. */
 @JvmName("immutableOf")
 fun KmFunction.immutable(): ImmutableKmFunction {
   return ImmutableKmFunction(
@@ -218,9 +218,9 @@ fun KmFunction.immutable(): ImmutableKmFunction {
       typeParameters.map { it.immutable() },
       receiverParameterType,
       valueParameters.map { it.immutable() },
-      returnType,
+      returnType.immutable(),
       versionRequirements.map { it.immutable() },
-      contract
+      contract?.immutable()
   )
 }
 
@@ -244,23 +244,23 @@ data class ImmutableKmFunction internal constructor(
     val typeParameters: List<ImmutableKmTypeParameter>,
     val receiverParameterType: KmType?,
     val valueParameters: List<ImmutableKmValueParameter>,
-    val returnType: KmType,
+    val returnType: ImmutableKmType,
     val versionRequirements: List<ImmutableKmVersionRequirement>,
-    val contract: KmContract?
+    val contract: ImmutableKmContract?
 ) {
   fun mutable(): KmFunction {
     return KmFunction(flags, name).apply {
       typeParameters += this@ImmutableKmFunction.typeParameters.map { it.mutable() }
       receiverParameterType = this@ImmutableKmFunction.receiverParameterType
       valueParameters += this@ImmutableKmFunction.valueParameters.map { it.mutable() }
-      returnType = this@ImmutableKmFunction.returnType
+      returnType = this@ImmutableKmFunction.returnType.mutable()
       versionRequirements += this@ImmutableKmFunction.versionRequirements.map { it.mutable() }
-      contract = this@ImmutableKmFunction.contract
+      contract = this@ImmutableKmFunction.contract?.mutable()
     }
   }
 }
 
-/** @return an immutable instance of this [KmProperty]. */
+/** @return an immutable representation of this [KmProperty]. */
 @JvmName("immutableOf")
 fun KmProperty.immutable(): ImmutableKmProperty {
   return ImmutableKmProperty(
@@ -269,9 +269,9 @@ fun KmProperty.immutable(): ImmutableKmProperty {
       getterFlags,
       setterFlags,
       typeParameters.map { it.immutable() },
-      receiverParameterType,
-      setterParameter,
-      returnType,
+      receiverParameterType?.immutable(),
+      setterParameter?.immutable(),
+      returnType.immutable(),
       versionRequirements.map { it.immutable() }
   )
 }
@@ -299,31 +299,31 @@ data class ImmutableKmProperty internal constructor(
     val getterFlags: Flags,
     val setterFlags: Flags,
     val typeParameters: List<ImmutableKmTypeParameter>,
-    val receiverParameterType: KmType?,
-    val setterParameter: KmValueParameter?,
-    val returnType: KmType,
+    val receiverParameterType: ImmutableKmType?,
+    val setterParameter: ImmutableKmValueParameter?,
+    val returnType: ImmutableKmType,
     val versionRequirements: List<ImmutableKmVersionRequirement>
 ) {
   fun mutable(): KmProperty {
     return KmProperty(flags, name, getterFlags, setterFlags).apply {
       typeParameters += this@ImmutableKmProperty.typeParameters.map { it.mutable() }
-      receiverParameterType = this@ImmutableKmProperty.receiverParameterType
-      setterParameter = this@ImmutableKmProperty.setterParameter
-      returnType = this@ImmutableKmProperty.returnType
+      receiverParameterType = this@ImmutableKmProperty.receiverParameterType?.mutable()
+      setterParameter = this@ImmutableKmProperty.setterParameter?.mutable()
+      returnType = this@ImmutableKmProperty.returnType.mutable()
       versionRequirements += this@ImmutableKmProperty.versionRequirements.map { it.mutable() }
     }
   }
 }
 
-/** @return an immutable instance of this [KmTypeAlias]. */
+/** @return an immutable representation of this [KmTypeAlias]. */
 @JvmName("immutableOf")
 fun KmTypeAlias.immutable(): ImmutableKmTypeAlias {
   return ImmutableKmTypeAlias(
       flags,
       name,
       typeParameters.map { it.immutable() },
-      underlyingType,
-      expandedType,
+      underlyingType.immutable(),
+      expandedType.immutable(),
       annotations.unmodifiable(),
       versionRequirements.map { it.immutable() }
   )
@@ -349,30 +349,30 @@ data class ImmutableKmTypeAlias internal constructor(
     val flags: Flags,
     val name: String,
     val typeParameters: List<ImmutableKmTypeParameter>,
-    val underlyingType: KmType,
-    val expandedType: KmType,
+    val underlyingType: ImmutableKmType,
+    val expandedType: ImmutableKmType,
     val annotations: List<KmAnnotation>,
     val versionRequirements: List<ImmutableKmVersionRequirement>
 ) {
   fun mutable(): KmTypeAlias {
     return KmTypeAlias(flags, name).apply {
       typeParameters += this@ImmutableKmTypeAlias.typeParameters.map { it.mutable() }
-      underlyingType = this@ImmutableKmTypeAlias.underlyingType
-      expandedType = this@ImmutableKmTypeAlias.expandedType
+      underlyingType = this@ImmutableKmTypeAlias.underlyingType.mutable()
+      expandedType = this@ImmutableKmTypeAlias.expandedType.mutable()
       annotations += this@ImmutableKmTypeAlias.annotations
       versionRequirements += this@ImmutableKmTypeAlias.versionRequirements.map { it.mutable() }
     }
   }
 }
 
-/** @return an immutable instance of this [KmValueParameter]. */
+/** @return an immutable representation of this [KmValueParameter]. */
 @JvmName("immutableOf")
 fun KmValueParameter.immutable(): ImmutableKmValueParameter {
   return ImmutableKmValueParameter(
       flags,
       name,
-      type,
-      varargElementType
+      type?.immutable(),
+      varargElementType?.immutable()
   )
 }
 
@@ -389,18 +389,18 @@ fun KmValueParameter.immutable(): ImmutableKmValueParameter {
 data class ImmutableKmValueParameter internal constructor(
     val flags: Flags,
     val name: String,
-    val type: KmType?,
-    val varargElementType: KmType?
+    val type: ImmutableKmType?,
+    val varargElementType: ImmutableKmType?
 ) {
   fun mutable(): KmValueParameter {
     return KmValueParameter(flags, name).apply {
-      type = this@ImmutableKmValueParameter.type
-      varargElementType = this@ImmutableKmValueParameter.varargElementType
+      type = this@ImmutableKmValueParameter.type?.mutable()
+      varargElementType = this@ImmutableKmValueParameter.varargElementType?.mutable()
     }
   }
 }
 
-/** @return an immutable instance of this [KmTypeParameter]. */
+/** @return an immutable representation of this [KmTypeParameter]. */
 @JvmName("immutableOf")
 fun KmTypeParameter.immutable(): ImmutableKmTypeParameter {
   return ImmutableKmTypeParameter(
@@ -438,15 +438,15 @@ data class ImmutableKmTypeParameter internal constructor(
   }
 }
 
-/** @return an immutable instance of this [KmType]. */
+/** @return an immutable representation of this [KmType]. */
 @JvmName("immutableOf")
 fun KmType.immutable(): ImmutableKmType {
   return ImmutableKmType(
       flags,
       classifier,
       arguments.map { it.immutable() },
-      abbreviatedType,
-      outerType,
+      abbreviatedType?.immutable(),
+      outerType?.immutable(),
       flexibleTypeUpperBound
   )
 }
@@ -473,7 +473,7 @@ data class ImmutableKmType internal constructor(
      *
      * The type of the `foo`'s parameter in the metadata is actually `MutableList<Any>`, and its abbreviation is `A<Any>`.
      */
-    val abbreviatedType: KmType?,
+    val abbreviatedType: ImmutableKmType?,
     /**
      * Outer type of this type, if this type's classifier is an inner class. For example:
      *
@@ -484,7 +484,7 @@ data class ImmutableKmType internal constructor(
      * The type of the `foo`'s parameter in the metadata is `B<Byte>` (a type whose classifier is class `B`, and it has one type argument,
      * type `Byte?`), and its outer type is `A<*>` (a type whose classifier is class `A`, and it has one type argument, star projection).
      */
-    val outerType: KmType?,
+    val outerType: ImmutableKmType?,
     /**
      * Upper bound of this type, if this type is flexible. In that case, all other data refers to the lower bound of the type.
      *
@@ -496,14 +496,14 @@ data class ImmutableKmType internal constructor(
     return KmType(flags).apply {
       classifier = this@ImmutableKmType.classifier
       arguments += this@ImmutableKmType.arguments.map { it.mutable() }
-      abbreviatedType = this@ImmutableKmType.abbreviatedType
-      outerType = this@ImmutableKmType.outerType
+      abbreviatedType = this@ImmutableKmType.abbreviatedType?.mutable()
+      outerType = this@ImmutableKmType.outerType?.mutable()
       flexibleTypeUpperBound = this@ImmutableKmType.flexibleTypeUpperBound
     }
   }
 }
 
-/** @return an immutable instance of this [KmVersionRequirement]. */
+/** @return an immutable representation of this [KmVersionRequirement]. */
 @JvmName("immutableOf")
 fun KmVersionRequirement.immutable(): ImmutableKmVersionRequirement {
   return ImmutableKmVersionRequirement(
@@ -547,7 +547,7 @@ data class ImmutableKmVersionRequirement internal constructor(
   }
 }
 
-/** @return an immutable instance of this [KmContract]. */
+/** @return an immutable representation of this [KmContract]. */
 @JvmName("immutableOf")
 fun KmContract.immutable(): ImmutableKmContract {
   return ImmutableKmContract(effects.map { it.immutable() })
@@ -571,14 +571,14 @@ data class ImmutableKmContract internal constructor(val effects: List<ImmutableK
   }
 }
 
-/** @return an immutable instance of this [KmEffect]. */
+/** @return an immutable representation of this [KmEffect]. */
 @JvmName("immutableOf")
 fun KmEffect.immutable(): ImmutableKmEffect {
   return ImmutableKmEffect(
       type,
       invocationKind,
       constructorArguments.map { it.immutable() },
-      conclusion
+      conclusion?.immutable()
   )
 }
 
@@ -602,24 +602,24 @@ data class ImmutableKmEffect internal constructor(
     val type: KmEffectType,
     val invocationKind: KmEffectInvocationKind?,
     val constructorArguments: List<ImmutableKmEffectExpression>,
-    val conclusion: KmEffectExpression?
+    val conclusion: ImmutableKmEffectExpression?
 ) {
   fun mutable(): KmEffect {
     return KmEffect(type, invocationKind).apply {
       constructorArguments += this@ImmutableKmEffect.constructorArguments.map { it.mutable() }
-      conclusion = this@ImmutableKmEffect.conclusion
+      conclusion = this@ImmutableKmEffect.conclusion?.mutable()
     }
   }
 }
 
-/** @return an immutable instance of this [KmEffectExpression]. */
+/** @return an immutable representation of this [KmEffectExpression]. */
 @JvmName("immutableOf")
 fun KmEffectExpression.immutable(): ImmutableKmEffectExpression {
   return ImmutableKmEffectExpression(
       flags,
       parameterIndex,
       constantValue,
-      isInstanceType,
+      isInstanceType?.immutable(),
       andArguments.map { it.immutable() },
       orArguments.map { it.immutable() }
   )
@@ -648,7 +648,7 @@ data class ImmutableKmEffectExpression internal constructor(
     val flags: Flags,
     val parameterIndex: Int?,
     val constantValue: KmConstantValue?,
-    val isInstanceType: KmType?,
+    val isInstanceType: ImmutableKmType?,
     val andArguments: List<ImmutableKmEffectExpression>,
     val orArguments: List<ImmutableKmEffectExpression>
 ) {
@@ -657,15 +657,17 @@ data class ImmutableKmEffectExpression internal constructor(
       flags = this@ImmutableKmEffectExpression.flags
       parameterIndex = this@ImmutableKmEffectExpression.parameterIndex
       constantValue = this@ImmutableKmEffectExpression.constantValue
-      isInstanceType = this@ImmutableKmEffectExpression.isInstanceType
+      isInstanceType = this@ImmutableKmEffectExpression.isInstanceType?.mutable()
       andArguments += this@ImmutableKmEffectExpression.andArguments.map { it.mutable() }
       orArguments += this@ImmutableKmEffectExpression.orArguments.map { it.mutable() }
     }
   }
 }
 
+/** @return an immutable representation of this [KmTypeProjection]. */
+@JvmName("immutableOf")
 fun KmTypeProjection.immutable(): ImmutableKmTypeProjection {
-  return ImmutableKmTypeProjection(variance, type)
+  return ImmutableKmTypeProjection(variance, type?.immutable())
 }
 
 /**
@@ -677,10 +679,10 @@ fun KmTypeProjection.immutable(): ImmutableKmTypeProjection {
  * @property variance the variance of the type projection, or `null` if this is a star projection
  * @property type the projected type, or `null` if this is a star projection
  */
-data class ImmutableKmTypeProjection(val variance: KmVariance?, val type: KmType?) {
+data class ImmutableKmTypeProjection(val variance: KmVariance?, val type: ImmutableKmType?) {
 
   fun mutable(): KmTypeProjection {
-    return KmTypeProjection(variance, type)
+    return KmTypeProjection(variance, type?.mutable())
   }
 
   companion object {
@@ -690,6 +692,28 @@ data class ImmutableKmTypeProjection(val variance: KmVariance?, val type: KmType
      */
     @JvmField
     val STAR = KmTypeProjection.STAR
+  }
+}
+
+/** @return an immutable representation of this [KmFlexibleTypeUpperBound]. */
+@JvmName("immutableOf")
+fun KmFlexibleTypeUpperBound.immutable(): ImmutableKmFlexibleTypeUpperBound {
+  return ImmutableKmFlexibleTypeUpperBound(type.immutable(), typeFlexibilityId)
+}
+
+/**
+ * Immutable representation of [KmFlexibleTypeUpperBound].
+ *
+ * Represents an upper bound of a flexible Kotlin type.
+ *
+ * @property type upper bound of the flexible type
+ * @property typeFlexibilityId id of the kind of flexibility this type has. For example, "kotlin.jvm.PlatformType" for JVM platform types,
+ *                          or "kotlin.DynamicType" for JS dynamic type
+ */
+data class ImmutableKmFlexibleTypeUpperBound(val type: ImmutableKmType,
+    val typeFlexibilityId: String?) {
+  fun mutable(): KmFlexibleTypeUpperBound {
+    return KmFlexibleTypeUpperBound(type.mutable(), typeFlexibilityId)
   }
 }
 


### PR DESCRIPTION
Not comfortable with metric's Km types all being mutable, so this introduces a ABI-compatible immutable versions of them for use in metric under the hood for better safety and API usage if you want to pass them around