### PR TITLE
fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ kapt 'io.sweers.copydynamic:copydynamic:x.y.z'
 compileOnly 'io.sweers.copydynamic:copydynamic-annotations:x.y.z'
 ```
 
-KDocs can be found here: https://hzsweers.github.io/copydynamic/0.x
+KDocs can be found here: <https://zacsweers.github.io/copydynamic>
 
 License
 -------


### PR DESCRIPTION
The kdocs link in the README doesn't work (suffixed with `0.x` (tried 0.2, 0.2.0)) ... so I replaced it with the URL from the repo ...